### PR TITLE
Carthage Support

### DIFF
--- a/KVNProgress.xcodeproj/project.pbxproj
+++ b/KVNProgress.xcodeproj/project.pbxproj
@@ -32,6 +32,18 @@
 		1482704A1AE2B4E500873272 /* KVNProgressConfigurationTestsSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 148270491AE2B4E500873272 /* KVNProgressConfigurationTestsSpec.m */; };
 		1482704E1AE2CBB100873272 /* KVNUIColor+KVNContrastSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 1482704D1AE2CBB100873272 /* KVNUIColor+KVNContrastSpec.m */; };
 		B7AEA695F14877870205F81C /* libPods-KVNProgressTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B43D6870AC5276C24F2B9384 /* libPods-KVNProgressTests.a */; };
+		FF5F4FEE1C18F0F400177A67 /* KVNProgressKit.h in Headers */ = {isa = PBXBuildFile; fileRef = FF5F4FED1C18F0F400177A67 /* KVNProgressKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FF5F4FF31C18F17D00177A67 /* UIImage+KVNImageEffects.m in Sources */ = {isa = PBXBuildFile; fileRef = 0AA0DD271930E62A00FDD29F /* UIImage+KVNImageEffects.m */; };
+		FF5F4FF41C18F17D00177A67 /* UIImage+KVNEmpty.m in Sources */ = {isa = PBXBuildFile; fileRef = 0AA0DD2F1931EB3D00FDD29F /* UIImage+KVNEmpty.m */; };
+		FF5F4FF51C18F17D00177A67 /* UIColor+KVNContrast.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A835D681AB339E900CB321A /* UIColor+KVNContrast.m */; };
+		FF5F4FF61C18F17D00177A67 /* KVNProgressView.xib in Sources */ = {isa = PBXBuildFile; fileRef = 0AA0DD2C1930F76A00FDD29F /* KVNProgressView.xib */; };
+		FF5F4FF71C18F17D00177A67 /* KVNProgress.m in Sources */ = {isa = PBXBuildFile; fileRef = 0AA0DD231930E0C000FDD29F /* KVNProgress.m */; };
+		FF5F4FF81C18F17D00177A67 /* KVNProgressConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A53757A1A45784200A7743C /* KVNProgressConfiguration.m */; };
+		FF5F4FF91C18F18E00177A67 /* UIImage+KVNImageEffects.h in Headers */ = {isa = PBXBuildFile; fileRef = 0AA0DD261930E62A00FDD29F /* UIImage+KVNImageEffects.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FF5F4FFA1C18F18E00177A67 /* UIImage+KVNEmpty.h in Headers */ = {isa = PBXBuildFile; fileRef = 0AA0DD2E1931EB3D00FDD29F /* UIImage+KVNEmpty.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FF5F4FFB1C18F18E00177A67 /* UIColor+KVNContrast.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A835D671AB339E900CB321A /* UIColor+KVNContrast.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FF5F4FFC1C18F18E00177A67 /* KVNProgress.h in Headers */ = {isa = PBXBuildFile; fileRef = 0AA0DD221930E0C000FDD29F /* KVNProgress.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FF5F4FFD1C18F18E00177A67 /* KVNProgressConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A5375791A45784200A7743C /* KVNProgressConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -83,6 +95,9 @@
 		1482704D1AE2CBB100873272 /* KVNUIColor+KVNContrastSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "KVNUIColor+KVNContrastSpec.m"; sourceTree = "<group>"; };
 		AC926D9E042446C786108BC3 /* Pods-KVNProgressTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KVNProgressTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-KVNProgressTests/Pods-KVNProgressTests.release.xcconfig"; sourceTree = "<group>"; };
 		B43D6870AC5276C24F2B9384 /* libPods-KVNProgressTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-KVNProgressTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FF5F4FEB1C18F0F400177A67 /* KVNProgressKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = KVNProgressKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FF5F4FED1C18F0F400177A67 /* KVNProgressKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KVNProgressKit.h; sourceTree = "<group>"; };
+		FF5F4FEF1C18F0F400177A67 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -107,6 +122,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FF5F4FE71C18F0F400177A67 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -128,6 +150,7 @@
 			children = (
 				0AA0DCF01930DFAD00FDD29F /* KVNProgress */,
 				0AA0DD0F1930DFAD00FDD29F /* KVNProgressTests */,
+				FF5F4FEC1C18F0F400177A67 /* KVNProgressKit */,
 				0AA0DCE91930DFAD00FDD29F /* Frameworks */,
 				0AA0DCE81930DFAD00FDD29F /* Products */,
 				CB962F7FECF6EC14A938952F /* Pods */,
@@ -139,6 +162,7 @@
 			children = (
 				0AA0DCE71930DFAD00FDD29F /* KVNProgress.app */,
 				0AA0DD081930DFAD00FDD29F /* KVNProgressTests.xctest */,
+				FF5F4FEB1C18F0F400177A67 /* KVNProgressKit.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -242,7 +266,32 @@
 			name = Pods;
 			sourceTree = "<group>";
 		};
+		FF5F4FEC1C18F0F400177A67 /* KVNProgressKit */ = {
+			isa = PBXGroup;
+			children = (
+				FF5F4FED1C18F0F400177A67 /* KVNProgressKit.h */,
+				FF5F4FEF1C18F0F400177A67 /* Info.plist */,
+			);
+			path = KVNProgressKit;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		FF5F4FE81C18F0F400177A67 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FF5F4FEE1C18F0F400177A67 /* KVNProgressKit.h in Headers */,
+				FF5F4FF91C18F18E00177A67 /* UIImage+KVNImageEffects.h in Headers */,
+				FF5F4FFA1C18F18E00177A67 /* UIImage+KVNEmpty.h in Headers */,
+				FF5F4FFB1C18F18E00177A67 /* UIColor+KVNContrast.h in Headers */,
+				FF5F4FFC1C18F18E00177A67 /* KVNProgress.h in Headers */,
+				FF5F4FFD1C18F18E00177A67 /* KVNProgressConfiguration.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
 		0AA0DCE61930DFAD00FDD29F /* KVNProgress */ = {
@@ -284,6 +333,24 @@
 			productReference = 0AA0DD081930DFAD00FDD29F /* KVNProgressTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		FF5F4FEA1C18F0F400177A67 /* KVNProgressKit */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FF5F4FF21C18F0F400177A67 /* Build configuration list for PBXNativeTarget "KVNProgressKit" */;
+			buildPhases = (
+				FF5F4FE61C18F0F400177A67 /* Sources */,
+				FF5F4FE71C18F0F400177A67 /* Frameworks */,
+				FF5F4FE81C18F0F400177A67 /* Headers */,
+				FF5F4FE91C18F0F400177A67 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = KVNProgressKit;
+			productName = KVNProgressKit;
+			productReference = FF5F4FEB1C18F0F400177A67 /* KVNProgressKit.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -299,6 +366,9 @@
 					};
 					0AA0DD071930DFAD00FDD29F = {
 						TestTargetID = 0AA0DCE61930DFAD00FDD29F;
+					};
+					FF5F4FEA1C18F0F400177A67 = {
+						CreatedOnToolsVersion = 7.1;
 					};
 				};
 			};
@@ -317,6 +387,7 @@
 			targets = (
 				0AA0DCE61930DFAD00FDD29F /* KVNProgress */,
 				0AA0DD071930DFAD00FDD29F /* KVNProgressTests */,
+				FF5F4FEA1C18F0F400177A67 /* KVNProgressKit */,
 			);
 		};
 /* End PBXProject section */
@@ -338,6 +409,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				0AA0DD141930DFAD00FDD29F /* InfoPlist.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FF5F4FE91C18F0F400177A67 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -429,6 +507,19 @@
 				0AA0DD161930DFAD00FDD29F /* KVNProgressTests.m in Sources */,
 				140C0D7A1AE2DB8C0029C90A /* KVNUIImage_KVNEmptySpec.m in Sources */,
 				1482704E1AE2CBB100873272 /* KVNUIColor+KVNContrastSpec.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FF5F4FE61C18F0F400177A67 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FF5F4FF31C18F17D00177A67 /* UIImage+KVNImageEffects.m in Sources */,
+				FF5F4FF41C18F17D00177A67 /* UIImage+KVNEmpty.m in Sources */,
+				FF5F4FF51C18F17D00177A67 /* UIColor+KVNContrast.m in Sources */,
+				FF5F4FF61C18F17D00177A67 /* KVNProgressView.xib in Sources */,
+				FF5F4FF71C18F17D00177A67 /* KVNProgress.m in Sources */,
+				FF5F4FF81C18F17D00177A67 /* KVNProgressConfiguration.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -629,6 +720,60 @@
 			};
 			name = Release;
 		};
+		FF5F4FF01C18F0F400177A67 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = KVNProgressKit/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.kevin.hirsch.kvnprogress.KVNProgressKit;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		FF5F4FF11C18F0F400177A67 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = KVNProgressKit/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = com.kevin.hirsch.kvnprogress.KVNProgressKit;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -658,6 +803,14 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		FF5F4FF21C18F0F400177A67 /* Build configuration list for PBXNativeTarget "KVNProgressKit" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FF5F4FF01C18F0F400177A67 /* Debug */,
+				FF5F4FF11C18F0F400177A67 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 /* End XCConfigurationList section */
 	};

--- a/KVNProgress.xcodeproj/xcshareddata/xcschemes/KVNProgressKit.xcscheme
+++ b/KVNProgress.xcodeproj/xcshareddata/xcschemes/KVNProgressKit.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0710"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FF5F4FEA1C18F0F400177A67"
+               BuildableName = "KVNProgressKit.framework"
+               BlueprintName = "KVNProgressKit"
+               ReferencedContainer = "container:KVNProgress.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FF5F4FEA1C18F0F400177A67"
+            BuildableName = "KVNProgressKit.framework"
+            BlueprintName = "KVNProgressKit"
+            ReferencedContainer = "container:KVNProgress.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FF5F4FEA1C18F0F400177A67"
+            BuildableName = "KVNProgressKit.framework"
+            BlueprintName = "KVNProgressKit"
+            ReferencedContainer = "container:KVNProgress.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/KVNProgress/Categories/UIColor+KVNContrast.h
+++ b/KVNProgress/Categories/UIColor+KVNContrast.h
@@ -8,6 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
+
 @interface UIColor (KVNContrast)
 
 - (UIStatusBarStyle)statusBarStyleConstrastStyle;

--- a/KVNProgress/Categories/UIImage+KVNEmpty.h
+++ b/KVNProgress/Categories/UIImage+KVNEmpty.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Kevin Hirsch. All rights reserved.
 //
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 
 @interface UIImage (KVNEmpty)
 

--- a/KVNProgress/Categories/UIImage+KVNImageEffects.h
+++ b/KVNProgress/Categories/UIImage+KVNImageEffects.h
@@ -93,7 +93,7 @@
  5/3/2013
  */
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 
 @interface UIImage (KVNImageEffects)
 

--- a/KVNProgressKit/Info.plist
+++ b/KVNProgressKit/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/KVNProgressKit/KVNProgressKit.h
+++ b/KVNProgressKit/KVNProgressKit.h
@@ -1,0 +1,26 @@
+//
+//  KVNProgressKit.h
+//  KVNProgressKit
+//
+//  Created by Raunak Roy on 12/9/15.
+//  Copyright © 2015 Pinch. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+#import "KVNProgress.h"
+#import "KVNProgressConfiguration.h"
+
+#import "UIImage+KVNImageEffects.h"
+#import "UIImage+KVNEmpty.h"
+#import "UIColor+KVNContrast.h"
+
+//! Project version number for KVNProgressKit.
+FOUNDATION_EXPORT double KVNProgressKitVersionNumber;
+
+//! Project version string for KVNProgressKit.
+FOUNDATION_EXPORT const unsigned char KVNProgressKitVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <KVNProgressKit/PublicHeader.h>
+
+


### PR DESCRIPTION
- expose a shared framework scheme
- by default exposed all non-example app headers
- slightly modify imports because build was complaining about not finding `UIColor` in a category header
