### PR TITLE
- Color components crash fix

### DIFF
--- a/KVNProgress/Categories/UIColor+KVNContrast.m
+++ b/KVNProgress/Categories/UIColor+KVNContrast.m
@@ -12,14 +12,22 @@
 
 - (UIStatusBarStyle)statusBarStyleConstrastStyle
 {
-	const CGFloat *componentColors = CGColorGetComponents(self.CGColor);
-	CGFloat darknessScore = (((componentColors[0] * 255) * 299) + ((componentColors[1] * 255) * 587) + ((componentColors[2] * 255) * 114)) / 1000;
-	
-	if (darknessScore >= 125) {
-		return UIStatusBarStyleDefault;
-	}
-	
-	return UIStatusBarStyleLightContent;
+    CGColorRef cgColor = self.CGColor;
+    size_t count = CGColorGetNumberOfComponents(cgColor);
+    const CGFloat *componentColors = CGColorGetComponents(cgColor);
+    
+    CGFloat darknessScore = 0;
+    if (count == 2) {
+        darknessScore = (((componentColors[0]*255) * 299) + ((componentColors[0]*255) * 587) + ((componentColors[0]*255) * 114)) / 1000;
+    } else if (count == 4) {
+        darknessScore = (((componentColors[0]*255) * 299) + ((componentColors[1]*255) * 587) + ((componentColors[2]*255) * 114)) / 1000;
+    }
+    
+    if (darknessScore >= 125) {
+        return UIStatusBarStyleDefault;
+    }
+    
+    return UIStatusBarStyleLightContent;
 }
 
 @end


### PR DESCRIPTION
If color have less then 3 components `-statusBarStyleConstrastStyle` in `UIColor+KVNContrast.m` will cause a crash. Check here: http://stackoverflow.com/a/18303674/4124265