### PR TITLE
Remove GLKit

### DIFF
--- a/KVNProgress.podspec
+++ b/KVNProgress.podspec
@@ -17,6 +17,6 @@ Pod::Spec.new do |s|
   s.source_files  = "KVNProgress/Classes", "KVNProgress/Classes/**/*.{h,m}", "KVNProgress/Categories", "KVNProgress/Categories/**/*.{h,m}"
   s.resources = "KVNProgress/Resources/*.{png,xib}"
 
-  s.frameworks = "QuartzCore", "GLKit"
+  s.frameworks = "QuartzCore"
   s.requires_arc = true
 end

--- a/KVNProgress/Classes/KVNProgress.m
+++ b/KVNProgress/Classes/KVNProgress.m
@@ -7,7 +7,6 @@
 //
 
 @import QuartzCore;
-@import GLKit;
 
 #import "KVNProgress.h"
 
@@ -696,6 +695,10 @@ static KVNProgressConfiguration *configuration;
 	[self removeAllSubLayersOfLayer:self.circleProgressView.layer];
 }
 
+CGFloat degreesToRadians (CGFloat deg) {
+	return deg * (M_PI / 180.0f);
+}
+
 - (void)setupInfiniteCircle
 {
 	CGFloat radius = (self.configuration.circleSize / 2.0f);
@@ -703,8 +706,8 @@ static KVNProgressConfiguration *configuration;
 	
 	UIBezierPath *circlePath = [UIBezierPath bezierPathWithArcCenter:center
 															  radius:(radius - self.configuration.lineWidth)
-														  startAngle:GLKMathDegreesToRadians(-45.0f)
-															endAngle:GLKMathDegreesToRadians(275.0f)
+														  startAngle:degreesToRadians(-45.0f)
+															endAngle:degreesToRadians(275.0f)
 														   clockwise:YES];
 	
 	self.circleProgressLineLayer = [CAShapeLayer layer];
@@ -727,8 +730,8 @@ static KVNProgressConfiguration *configuration;
 	
 	UIBezierPath *circlePath = [UIBezierPath bezierPathWithArcCenter:center
 															  radius:(radius - self.configuration.lineWidth)
-														  startAngle:GLKMathDegreesToRadians(-90.0f)
-															endAngle:GLKMathDegreesToRadians(275.0f)
+														  startAngle:degreesToRadians(-90.0f)
+															endAngle:degreesToRadians(275.0f)
 														   clockwise:YES];
 	
 	[self cancelCircleAnimation];
@@ -853,8 +856,8 @@ static KVNProgressConfiguration *configuration;
 	// Circle
 	UIBezierPath *circlePath = [UIBezierPath bezierPathWithArcCenter:center
 															  radius:(radius - self.configuration.lineWidth)
-														  startAngle:GLKMathDegreesToRadians(-90.0f)
-															endAngle:GLKMathDegreesToRadians(275.0f)
+														  startAngle:degreesToRadians(-90.0f)
+															endAngle:degreesToRadians(275.0f)
 														   clockwise:YES];
 	
 	self.circleProgressLineLayer = [CAShapeLayer layer];


### PR DESCRIPTION
According to https://github.com/AssistoLab/KVNProgress/issues/121.

This PR removes GLKit and the `GLKit is deprecated. Consider migrating to MetalKit instead.` warning.

In exchange, a function has been added to convert degrees to radians.